### PR TITLE
🤖 ci: binary resolution

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Compute next version
         id: semver
         run: |
-          VERSION=$(rs-compute-version || echo "")
+          VERSION=$(npx rs-compute-version || echo "")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Stop if no release needed
@@ -68,7 +68,7 @@ jobs:
         run: npm run build --if-present
 
       - name: Generate changelog
-        run: rs-generate-changelog
+        run: npx rs-generate-changelog
 
       # Automatically create branches, commits, and PRs with peter-evans
       - name: Create Release PR

--- a/.github/workflows/publish-on-merge.yml
+++ b/.github/workflows/publish-on-merge.yml
@@ -48,7 +48,7 @@ jobs:
         run: npm run build --if-present
 
       - name: Create Git Tag
-        run: rs-create-tag
+        run: npx rs-create-tag
 
       # Publish to npm using Trusted Publishing (OIDC)
       - name: Publish to npm (Trusted Publishing)
@@ -56,7 +56,7 @@ jobs:
 
       # Generate release notes for GitHub Release
       - name: Generate GitHub Release Notes
-        run: rs-generate-release-notes
+        run: npx rs-generate-release-notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ npm install release-suite --save-dev
 | `rs-preview`                | Generates preview changelog & release notes               |
 | `rs-create-tag`             | Create and push a git tag based on `package.json` version |
 
+> 💡 **Note about execution**
+>
+> - When using these commands via `npm run`, they can be referenced directly (`rs-*`).
+> - In CI/CD environments (e.g. GitHub Actions), always invoke them using `npx`
+>   (e.g. `npx rs-generate-changelog`) to ensure proper binary resolution.
+
 ## 🧠 Usage
 
 Add to your project's `package.json`:
@@ -49,6 +55,8 @@ Add to your project's `package.json`:
 ```
 
 ## 🤖 CI/CD Usage (GitHub Actions)
+
+> ℹ️ In CI/CD environments, always use `npx` when invoking `rs-*` commands.
 
 This project is designed to be used in automated pipelines.
 


### PR DESCRIPTION
## 🛠️ Summary of Adjustments

Fixed the `command not found` error in workflows, as GitHub Actions does NOT automatically add `node_modules/.bin` to the PATH
for direct shell commands.

```bash
Run rs-generate-changelog
/home/runner/work/_temp/2c1b3c85-b663-472a-9b4e-bd0fd9800278.sh: line 1: rs-generate-changelog: command not found
Error: Process completed with exit code 127.
```

✅ In CI/CD environments (e.g., GitHub Actions), always invoke them using `npx`  to ensure proper binary resolution.
  e.g.
```yml
      - name: Generate changelog
        run: npx rs-generate-changelog
```

Fixed workflows:
- `create-release-pr.yml`
- `publish-on-merge.yml`