### PR TITLE
:bug: fix: harden changelog generation for squash commits

### DIFF
--- a/bin/generate-changelog.js
+++ b/bin/generate-changelog.js
@@ -3,6 +3,9 @@ import { execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { COMMIT_RE, COMMIT_EMOJI_RE } from "../lib/constants.js";
+import { normalizeCommits, parseCommit } from "../lib/git.js";
+import { normalizeSubject } from "../lib/versioning.js";
 import { computeVersion } from "./compute-version.js";
 
 function run(cmd, cwd = process.cwd()) {
@@ -37,26 +40,22 @@ function getAllTags(cwd = process.cwd()) {
 
 function getCommitsBetween(from, to, cwd = process.cwd()) {
   const range = from ? `${from}..${to}` : to;
+
   try {
-    return run(`git log ${range} --pretty=format:%H%x1f%s%x1f%b`, cwd)
-      .split("\n")
+    return run(
+      `git log ${range} --pretty=format:%H%x1f%s%x1f%B%x1e`,
+      cwd
+    )
+      .split("\x1e")
+      .map(c => c.trim())
       .filter(Boolean);
   } catch {
     return [];
   }
 }
 
-function parseCommit(line) {
-  const [hash, subject = "", body = ""] = line.split("\x1f");
-  return { hash, subject: subject.trim(), body: body.trim() };
-}
-
 function cleanSubject(subject) {
-  let s = subject.replace(/^(:\S+: )?/, "");
-  s = s.replace(
-    /^(feat|fix|refactor|docs|chore|style|test|build|perf|ci|raw|cleanup|remove)(\(.+\))?(!)?:\s*/i,
-    ""
-  );
+  const s = normalizeSubject(subject).replace(COMMIT_RE, "");
   return s ? s.charAt(0).toUpperCase() + s.slice(1) : s;
 }
 
@@ -78,9 +77,6 @@ function categorize(commits) {
     remove: [],
   };
 
-  const reType =
-    /^(:\S+: )?(feat|fix|refactor|docs|chore|style|test|build|perf|ci|raw|cleanup|remove)(\(.+\))?(!)?:/i;
-
   for (const c of commits) {
     const { subject, body } = c;
 
@@ -89,7 +85,7 @@ function categorize(commits) {
       continue;
     }
 
-    const match = subject.match(reType);
+    const match = subject.match(COMMIT_EMOJI_RE);
     const desc = cleanSubject(subject);
 
     if (!match) {
@@ -98,7 +94,14 @@ function categorize(commits) {
     }
 
     const type = match[2].toLowerCase();
-    (buckets[type] || buckets.chore).push({ desc, hash: c.hash });
+    const finalDesc = desc || cleanSubject(subject) || subject;
+
+    if (finalDesc && finalDesc.trim()) {
+      (buckets[type] || buckets.chore).push({
+        desc: finalDesc.trim(),
+        hash: c.hash
+      });
+    }
   }
 
   return buckets;
@@ -128,12 +131,18 @@ function buildSection(version, buckets) {
   let hasContent = false;
 
   for (const [key, title] of sections) {
-    if (buckets[key].length) {
-      hasContent = true;
-      out.push(`${title}\n`);
-      for (const c of buckets[key]) out.push(`- ${c.desc}`);
-      out.push("");
+    const items = buckets[key]
+      .map(c => c.desc && c.desc.trim())
+      .filter(Boolean);
+
+    if (!items.length) continue;
+
+    hasContent = true;
+    out.push(`${title}\n`);
+    for (const desc of items) {
+      out.push(`- ${desc}`);
     }
+    out.push("");
   }
 
   if (!hasContent) out.push("_No changes._\n");
@@ -165,7 +174,10 @@ export function generateChangelog({ isPreview = process.env.PREVIEW_MODE === "tr
 
   // Always generate the upcoming version (preview & release)
   if (!changelogHasVersion(CHANGELOG_FILE, nextVersion, cwd)) {
-    const commits = getCommitsBetween(lastTag, "HEAD", cwd).map(parseCommit);
+    const commits = normalizeCommits(
+      getCommitsBetween(lastTag, "HEAD", cwd).map(parseCommit)
+    );
+
 
     if (commits.length) {
       const buckets = categorize(commits);
@@ -180,7 +192,11 @@ export function generateChangelog({ isPreview = process.env.PREVIEW_MODE === "tr
 
     if (changelogHasVersion(CHANGELOG_FILE, tag, cwd)) continue;
 
-    const commits = getCommitsBetween(previous, tag, cwd).map(parseCommit);
+    const commits = normalizeCommits(
+      getCommitsBetween(previous, tag, cwd)
+        .map(parseCommit)
+    );
+
     if (!commits.length) continue;
 
     const buckets = categorize(commits);

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,28 @@
+// Constants used across the release-suite package
+
+// Commit types recognized in Conventional Commits
+export const COMMIT_TYPES = [
+  'feat',
+  'fix',
+  'refactor',
+  'docs',
+  'chore',
+  'style',
+  'test',
+  'build',
+  'perf',
+  'ci',
+  'raw',
+  'cleanup',
+  'remove',
+].join('|');
+
+export const COMMIT_RE = new RegExp(
+  `^(${COMMIT_TYPES})(\\(.+\\))?(!)?:\\s*`,
+  'i'
+);
+
+export const COMMIT_EMOJI_RE = new RegExp(
+  `^(:\\S+: )?(${COMMIT_TYPES})(\\(.+\\))?(!)?:`,
+  'i'
+);

--- a/lib/git.js
+++ b/lib/git.js
@@ -1,4 +1,6 @@
+import { COMMIT_RE } from "./constants.js";
 import { run } from "./utils.js";
+import { normalizeSubject } from "./versioning.js";
 
 /* ===========================
  * Git helpers
@@ -69,5 +71,59 @@ export function getCommits(range, cwd) {
  */
 export function parseCommit(line) {
   const [hash, subject = "", body = ""] = line.split("\x1f");
-  return { hash, subject, body };
+  return {
+    hash: hash.trim(),
+    subject: subject.trim(),
+    body: body.trim()
+  };
+}
+
+function isSquashCommit(commit) {
+  return /\n\s*[*-]\s+/.test(commit.body);
+}
+
+function extractCommitsFromSquash(commit) {
+  const lines = commit.body
+    .split("\n")
+    .map(l => l.trim())
+    .filter(Boolean);
+
+  const firstBulletIndex = lines.findIndex(
+    l => l.startsWith("* ") || l.startsWith("- ")
+  );
+
+  if (firstBulletIndex === -1) {
+    return [];
+  }
+
+  return lines
+    .slice(firstBulletIndex)
+    .filter(l => l.startsWith("* ") || l.startsWith("- "))
+    .map(l => normalizeSubject(l))
+    .filter(subject => COMMIT_RE.test(subject))
+    .map(subject => ({
+      hash: commit.hash,
+      subject,
+      body: ""
+    }));
+
+}
+
+export function normalizeCommits(commits) {
+  const normalized = [];
+
+  for (const commit of commits) {
+    if (isSquashCommit(commit)) {
+      const extracted = extractCommitsFromSquash(commit);
+      if (extracted.length) {
+        normalized.push(...extracted);
+        continue;
+      }
+    }
+
+    // fallback: normal commit
+    normalized.push(commit);
+  }
+
+  return normalized;
 }

--- a/lib/versioning.js
+++ b/lib/versioning.js
@@ -1,9 +1,8 @@
+import { COMMIT_RE } from "./constants.js";
+
 /* ===========================
  * Semver detection
  * =========================== */
-
-const COMMIT_RE =
-  /^(feat|fix|refactor|docs|chore|style|test|build|perf|ci|cleanup|remove)(\(.+\))?(!)?:/i;
 
 /**
  * Normalize a subject string by removing leading emoji and trimming whitespace.
@@ -25,12 +24,12 @@ const COMMIT_RE =
  * @example
  * normalizeSubject('  :a::b:Multiple emojis at start  ') // 'Multiple emojis at start'
  */
-function normalizeSubject(subject) {
+export function normalizeSubject(subject = "") {
   return subject
-    // remove emoji at start
-    .replace(/^:\S+:\s*/, "")
-    // remove unicode emoji at start
-    .replace(/^[\u{1F300}-\u{1FAFF}]+\s*/u, "")
+    .replace(/^[-*]\s*/, "") // leading list markers
+    .replace(/^:\w+:\s*/, "") // :emoji:
+    .replace(/^[^\w]+/, "")   // leading symbols
+    .replace(/^(?:[\u{1F300}-\u{1FAFF}]+\s*)+/u, "") // leading Unicode emoji
     .trim();
 }
 


### PR DESCRIPTION
## 🛠️ Summary of Adjustments

This PR hardens `CHANGELOG.md` generation by correctly handling squash commits, preventing empty sections, and centralizing commit parsing and normalization logic to ensure deterministic and consistent output.

## ✨ Main changes

- `lib/constants.js`
  - Introduction of the `COMMIT_TYPES`constant to define supported Conventional Commit types
  - Centralization of commit parsing regexes (`COMMIT_RE` and `COMMIT_EMOJI_RE`) based on this constant

- `lib/versioning.js`
  - Import and reuse of the shared `COMMIT_RE` constant
  - Refactoring and export of `normalizeSubject`, including enhanced regex handling for squash commit subjects

- `lib/git.js`
  - Import and reuse of `COMMIT_RE` and `normalizeSubject`
  - Introduction of squash-aware helpers:
    - `isSquashCommit`
    - `extractCommitsFromSquash`
    - `normalizeCommits`

- `bin/generate-changelog.js`
  - Reuse of centralized constants (`COMMIT_RE`, `COMMIT_EMOJI_RE`)
  - Reuse of shared helpers (`normalizeCommits`, `parseCommit`, `normalizeSubject`)
  - Removal of duplicated `parseCommit` implementation in favor of `ib/versioning.js`
  - Fix in `getCommitsBetween` to use **record separator**
  - Refactor of `cleanSubject` to rely on `COMMIT_RE` and `normalizeSubject`
  - Fix in categorize using `COMMIT_EMOJI_RE`, ensuring **0% empty lines**
  - Fix in `buildSection` to generate a section (`###`) **only when at least one item exists**
  - Refactor of `generateChangelog` to rely on `normalizeCommits` and `parseCommit`
