### PR TITLE
:robot: ci: simplify GitHub CLI usage and make authentication explicit

### DIFF
--- a/.github/workflows/create-and-publish.yml
+++ b/.github/workflows/create-and-publish.yml
@@ -23,6 +23,8 @@ jobs:
   create:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     # Job-level outputs = contract with publish job
     outputs:
@@ -133,14 +135,6 @@ jobs:
       # --------------------------------------------------------
       # Merge Release PR (best-effort)
       # --------------------------------------------------------
-      - name: Install GitHub CLI
-        if: steps.pr.outputs.pull-request-number != ''
-        uses: cli/gh-action@v2
-
-      - name: Authenticate gh
-        if: steps.pr.outputs.pull-request-number != ''
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
-
       - name: Merge Release PR
         if: steps.pr.outputs.pull-request-number != ''
         run: |
@@ -190,6 +184,9 @@ jobs:
   publish:
     needs: create
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     if: needs.create.outputs.tag != ''
 
@@ -228,12 +225,6 @@ jobs:
       # --------------------------------------------------------
       # Create GitHub Release with notes and attach built assets
       # --------------------------------------------------------
-      - name: Install GitHub CLI
-        uses: cli/gh-action@v2
-
-      - name: Authenticate gh
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
-
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 🛠️ Summary of Adjustments

This change simplifies the release workflow by removing unnecessary GitHub CLI setup steps and making authentication **explicit and deterministic** using environment variables.

The workflow now relies on the GitHub-hosted runner’s preinstalled `gh` CLI and explicitly provides credentials via `GH_TOKEN`, avoiding implicit behavior and reducing points of failure.

## ✨ Main changes

- Removed `cli/gh-action` usage (GitHub CLI is already available on `ubuntu-latest`)
- Removed `gh auth login` steps
- Explicitly set `GH_TOKEN` from `GITHUB_TOKEN` at job level
- Ensured all `gh` commands (`pr merge`, `release create`, etc.) authenticate consistently
- Reduced workflow complexity and eliminated external action dependency