### PR TITLE
:robot: ci: add Git identity before creating the tag

### DIFF
--- a/.github/workflows/create-and-publish.yml
+++ b/.github/workflows/create-and-publish.yml
@@ -167,18 +167,26 @@ jobs:
       # --------------------------------------------------------
       # Create Git tag (soft)
       # --------------------------------------------------------
+      - name: Configure Git identity (for tags)
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Create tag
         id: tag
         if: steps.validate.outputs.ok == 'true'
         run: |
           set +e
           RESULT=$(node bin/tag.js create)
+          STATUS=$?
           TAG=$(echo "$RESULT" | jq -r '.tag // empty')
 
           echo "$RESULT"
 
-          if [ -n "$TAG" ]; then
+          if [ "$STATUS" -eq 0 ] && [ -n "$TAG" ]; then
             echo "tag=$TAG" >> $GITHUB_OUTPUT
+          else
+            echo "Tag not created (soft-fail)"
           fi
 
   # ------------------------------------------------------------

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -172,18 +172,26 @@ jobs:
       # --------------------------------------------------------
       # Create Git tag (soft)
       # --------------------------------------------------------
+      - name: Configure Git identity (for tags)
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Create tag
         id: tag
         if: steps.validate.outputs.ok == 'true'
         run: |
           set +e
           RESULT=$(npx rs-tag create)
+          STATUS=$?
           TAG=$(echo "$RESULT" | jq -r '.tag // empty')
 
           echo "$RESULT"
 
-          if [ -n "$TAG" ]; then
+          if [ "$STATUS" -eq 0 ] && [ -n "$TAG" ]; then
             echo "tag=$TAG" >> $GITHUB_OUTPUT
+          else
+            echo "Tag not created (soft-fail)"
           fi
 
   # ------------------------------------------------------------


### PR DESCRIPTION
## 🛠️ Summary of Adjustments

This PR corrects the workflow, as the `Create Tag` step was failing with the error: `Committer identity unknown fatal: empty ident name (...) not allowed`... Therefore, the `Configure Git identity (for tags)` step was included for annotated tags before creating the tag. This way, Git now has `user.name` and `user.email` configured in the runner.

The `Create Tag` step has also been corrected to:
- maintain idempotence
- avoid false positives
- make the reason explicit