### PR TITLE
:bug: fix(cli): enforce LF line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Force LF in executable files (CLI)
+bin/* text eol=lf
+
+# JS / ESM code
+*.js   text eol=lf
+*.mjs  text eol=lf
+
+# Configurations
+*.json text eol=lf
+*.yml  text eol=lf
+*.yaml text eol=lf


### PR DESCRIPTION
## 🛠️ Summary of Adjustments

This PR fixes a CLI execution bug on Linux/WSL. 
It applies LF line endings via `.gitattributes` to fix CLI execution.
Although the file is “just configuration,” the actual effect is:
- fixes a real bug
- prevents CLI execution failure on Linux/WSL
- affects end users of the package.  

Therefore, this PR will replace release-suite 3.0.0 on npm published with CRLF.