### PR TITLE
:bug: fix: correct PR merge detection in release workflow

### DIFF
--- a/.github/workflows/create-and-publish.yml
+++ b/.github/workflows/create-and-publish.yml
@@ -155,9 +155,9 @@ jobs:
 
           echo "Waiting for PR #$PR to be merged..."
           for i in {1..60}; do
-            MERGED=$(gh pr view "$PR" --json merged -q .merged)
-            if [ "$MERGED" = "true" ]; then
-              echo "PR merged"
+            MERGED_AT=$(gh pr view "$PR" --json mergedAt -q .mergedAt)
+            if [ "$MERGED_AT" != "null" ] && [ -n "$MERGED_AT" ]; then
+              echo "PR merged at $MERGED_AT"
               exit 0
             fi
             sleep 5

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -176,9 +176,9 @@ jobs:
 
           echo "Waiting for PR #$PR to be merged..."
           for i in {1..60}; do
-            MERGED=$(gh pr view "$PR" --json merged -q .merged)
-            if [ "$MERGED" = "true" ]; then
-              echo "PR merged"
+            MERGED_AT=$(gh pr view "$PR" --json mergedAt -q .mergedAt)
+            if [ "$MERGED_AT" != "null" ] && [ -n "$MERGED_AT" ]; then
+              echo "PR merged at $MERGED_AT"
               exit 0
             fi
             sleep 5


### PR DESCRIPTION
## 🛠️ Summary of Adjustments

This PR fixes a workflow failure caused by the GitHub CLI returning:

`Unknown JSON field: "merged"`

The issue occurred in the step responsible for waiting until the Release PR is merged.

### Root Cause

The workflow attempted to query the `merged` field:

```bash
MERGED=$(gh pr view "$PR" --json merged -q .merged)
if [ "$MERGED" = "true" ]; then
```

However, the `merged` field is not supported in this context by the GitHub CLI, resulting in a runtime error.

### Solution

The check was replaced with the supported `mergedA` field:

```bash
MERGED_AT=$(gh pr view "$PR" --json mergedAt -q .mergedAt)
if [ "$MERGED_AT" != "null" ] && [ -n "$MERGED_AT" ]; then
```

Since `mergedAt` is only populated once the PR is actually merged, this provides a reliable and CLI-compatible way to detect merge completion.

### Result

- ✔ Eliminates the `Unknown JSON field error`
- ✔ Ensures deterministic detection of merged PRs
- ✔ Maintains compatibility with current GitHub CLI behavior
- ✔ Keeps the release workflow stable and predictable