### PR TITLE
:bug: fix: ensure correct tag checkout and stabilize release notes generation in Job 2

### DIFF
--- a/.github/workflows/create-and-publish.yml
+++ b/.github/workflows/create-and-publish.yml
@@ -199,9 +199,10 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - name: Checkout
+      - name: Checkout tag
         uses: actions/checkout@v4
         with:
+          ref: ${{ needs.create.outputs.tag }}
           fetch-depth: 0
           persist-credentials: true
 
@@ -217,6 +218,19 @@ jobs:
 
       - name: Install release-suite (self)
         run: npm install .
+
+      # --------------------------------------------------------
+      # Assert tag matches package.json
+      # --------------------------------------------------------
+      - name: Assert tag matches package.json
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          TAG=${{ needs.create.outputs.tag }}
+
+          if [ "$VERSION" != "$TAG" ]; then
+            echo "Version mismatch!"
+            exit 1
+          fi
 
       # --------------------------------------------------------
       # Guard: version already published?

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -219,9 +219,10 @@ jobs:
     if: needs.create.outputs.tag != ''
 
     steps:
-      - name: Checkout
+      - name: Checkout tag
         uses: actions/checkout@v4
         with:
+          ref: ${{ needs.create.outputs.tag }}
           fetch-depth: 0
           persist-credentials: true
 
@@ -234,6 +235,19 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      # --------------------------------------------------------
+      # Assert tag matches package.json
+      # --------------------------------------------------------
+      - name: Assert tag matches package.json
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          TAG=${{ needs.create.outputs.tag }}
+
+          if [ "$VERSION" != "$TAG" ]; then
+            echo "Version mismatch!"
+            exit 1
+          fi
 
       # --------------------------------------------------------
       # Guard: version already published?

--- a/lib/github.js
+++ b/lib/github.js
@@ -98,15 +98,18 @@ export function generateReleaseNotesViaAPI({
   targetBranch,
   cwd,
 }) {
-  let cmd = `
-gh api -X POST repos/${owner}/${repo}/releases/generate-notes \
-  -f tag_name='${currentTag}' \
-  -f target_commitish='${targetBranch}'
-`;
+  const args = [
+    "gh api -X POST",
+    `repos/${owner}/${repo}/releases/generate-notes`,
+    `-F tag_name=${currentTag}`,
+    `-F target_commitish=${targetBranch}`,
+  ];
 
-  if (previousTag) {
-    cmd += ` -f previous_tag_name='${previousTag}'`;
+  if (previousTag && previousTag !== currentTag) {
+    args.push(`-F previous_tag_name=${previousTag}`);
   }
+
+  const cmd = args.join(" ");
 
   return JSON.parse(run(cmd, cwd));
 }


### PR DESCRIPTION
## 🛠️ Summary of Adjustments

This PR fixes two failures in Job 2 of the release workflow.

## 1. npm publish step skipped (missing tag checkout)

The workflow was not checking out the created tag, causing the "Publish to npm using Trusted Publishing" step to be skipped.

### Fix
- Explicitly checkout the generated tag:
  - `actions/checkout@v4` with `ref: ${{ needs.create.outputs.tag }}`
  - `fetch-depth: 0`
- Added a safety check to assert that the checked-out tag matches `package.json` version.

This guarantees that:
- The correct version is published
- The workflow is deterministic
- Version mismatches fail fast

---

## 2. Release notes generation failure

The "Generate release notes for GitHub Release" step failed due to improper newline escaping and string concatenation in `generateReleaseNotesViaAPI`.

### Fix
- Replaced template literal + string concatenation with a command array
- Joined arguments safely before execution

This stabilizes command construction and prevents malformed CLI calls.

---

The workflow is now deterministic, tag-safe, and resilient during publishing and release note generation.