### PR TITLE
:sparkles: feat(config): introduce configurable releaseRules with safe defaults and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ This file controls:
 
 - Git tag prefix (`v1.2.3` vs `1.2.3`)
 - Emoji usage in changelog rendering
+- Commit-to-version mapping (via `releaseRules`)
 
 See [`docs/config.md`](docs/config.md) for full documentation.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -34,6 +34,11 @@ export default {
 
   changelog: {
     emojis: false
+  },
+
+  releaseRules: {
+    docs: "patch",
+    ci: "patch"
   }
 };
 ```
@@ -42,14 +47,17 @@ export default {
 
 ## ⚙️ Available options
 
+---
+
 ### `tag.prefix`
 
-Controls whether Git tags and release identifiers use a `v` prefix.
+Controls the prefix used in Git tags and release identifiers.
 
-| Value | Behavior                       |
-| ----- | ------------------------------ |
-| `"v"` | Tags are generated as `v1.2.3` |
-| `""`  | Tags are generated as `1.2.3`  |
+| Value   | Behavior                         |
+| ------- | -------------------------------- |
+| `"v"`   | Tags are generated as `v1.2.3`   |
+| `""`    | Tags are generated as `1.2.3`    |
+| custom  | Tags are generated as `x1.2.3`   |
 
 **Default:**
 
@@ -65,7 +73,7 @@ Controls whether Git tags and release identifiers use a `v` prefix.
 
 - `computeVersion` always returns the **pure semantic version** (`1.2.3`)
 - The prefix is applied only by consumers (create-tag, release-notes, workflows)
-- Any value other than `"v"` falls back to `""`
+- Any string value is accepted and treated as user responsibility
 
 ---
 
@@ -96,18 +104,100 @@ Controls whether emojis are used in `CHANGELOG.md` rendering.
 
 ---
 
+### `releaseRules`
+
+Controls how commit types map to semantic version bumps.
+
+```js
+releaseRules: {
+  docs: "patch",
+  ci: "patch",
+  refactor: "patch",
+  perf: "patch"
+}
+```
+
+| Value   | Meaning                    |
+| ------- | -------------------------- |
+| major   | Breaking change            |
+| minor   | New feature                |
+| patch   | Fix or non-breaking change |
+| none    | Ignored for versioning     |
+
+**Default:**
+
+```js
+{
+  releaseRules: {
+    feat: "minor",
+    fix: "patch"
+  }
+}
+```
+
+**Behavior:**
+
+- Rules are **merged with defaults**
+- Missing types fall back to default behavior
+- Unknown types are allowed
+- Invalid values throw an error
+
+**Protected types:**
+
+The following commit types **cannot be overridden**:
+
+```
+feat → always minor
+fix  → always patch
+```
+
+Any attempt to override them is ignored.
+
+**Example:**
+
+```js
+releaseRules: {
+  docs: "patch",
+  ci: "patch",
+  test: "none"
+}
+```
+
+Result:
+
+```js
+{
+  feat: "minor",
+  fix: "patch",
+  docs: "patch",
+  ci: "patch",
+  test: "none"
+}
+```
+
+---
+
 ## 🛡️ Defaults & fallback behavior
 
-If `release.config.js` does not exist, or if properties are missing or invalid, the following defaults apply:
+If `release.config.js` does not exist, or if properties are missing:
 
 ```js
 {
   tag: { prefix: "v" },
-  changelog: { emojis: false }
+  changelog: { emojis: false },
+  releaseRules: {
+    feat: "minor",
+    fix: "patch"
+  }
 }
 ```
 
-Invalid values **never throw errors** and **never propagate downstream**.
+**Rules:**
+
+- Missing fields → fallback to defaults
+- Partial configs → merged safely
+- Invalid values → throw explicit error (releaseRules)
+- No silent misconfiguration
 
 ---
 
@@ -115,7 +205,7 @@ Invalid values **never throw errors** and **never propagate downstream**.
 
 | Module          | Uses config                                  |
 | --------------- | -------------------------------------------- |
-| `version`       | Exposes `tagPrefix` in JSON output           |
+| `version`       | Applies `releaseRules` and exposes tagPrefix |
 | `create-tag`    | Applies `tag.prefix` when creating Git tags  |
 | `changelog`     | Renders emojis based on `changelog.emojis`   |
 | `release-notes` | Uses the same tag format                     |
@@ -128,12 +218,13 @@ Invalid values **never throw errors** and **never propagate downstream**.
 - Single source of truth
 - No duplicated CLI flags
 - Predictable defaults
-- Silent and safe fallback
-- Config validated at load time
+- Safe merging strategy
+- Explicit validation
+- User-controlled extensibility
 
 ---
 
 ## 📚 Versioning
 
 This configuration system was introduced in **Release Suite v3.0.0**
-and is considered a breaking change due to behavioral differences.
+and extended with `releaseRules` in later versions.

--- a/lib/config.js
+++ b/lib/config.js
@@ -2,34 +2,134 @@ import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
+const DEFAULT_CONFIG = {
+  tag: { prefix: "v" },
+  changelog: { emojis: false },
+
+  releaseRules: {
+    feat: "minor",
+    fix: "patch",
+  },
+};
+
+const VALID_BUMPS = ["major", "minor", "patch", "none"];
+const LOCKED_TYPES = ["feat", "fix"];
+
+/**
+ * Validate and normalize a mapping of commit types to release bump rules.
+ *
+ * The function:
+ * - Normalizes commit type keys to lowercase.
+ * - Skips any types present in the external LOCKED_TYPES array and emits a console.warn for each skipped type.
+ * - Validates each bump value against the external VALID_BUMPS array and throws an Error for invalid bumps.
+ * - Returns a new object containing only validated, non-locked mappings.
+ *
+ * @param {Object<string, string>} [rules={}] - An object mapping commit types to bump types (e.g. { feat: 'minor', fix: 'patch' }).
+ * @returns {Object<string, string>} A new object with lowercase commit type keys and validated bump values.
+ * @throws {Error} If a provided bump value is not included in VALID_BUMPS.
+ *
+ * @example
+ * // Assuming VALID_BUMPS = ['major','minor','patch'] and LOCKED_TYPES = ['chore']
+ * validateReleaseRules({ Feat: 'minor', docs: 'patch', Chore: 'major' })
+ * // => { feat: 'minor', docs: 'patch' } // 'Chore' ignored and console.warn emitted
+ *
+ * @remarks
+ * - This function has the side effect of logging warnings to the console for locked types.
+ * - It relies on the presence of LOCKED_TYPES and VALID_BUMPS in the surrounding scope.
+ */
+function validateReleaseRules(rules = {}) {
+  const safeRules = {};
+
+  for (const [type, bump] of Object.entries(rules)) {
+    const normalizedType = type.toLowerCase();
+
+    if (LOCKED_TYPES.includes(normalizedType)) {
+      console.warn(
+        `[release-config] Override ignored for "${normalizedType}". This type is locked.`
+      );
+      continue;
+    }
+
+    if (!VALID_BUMPS.includes(bump)) {
+      throw new Error(
+        `Invalid bump type "${bump}" for commit type "${type}"`
+      );
+    }
+
+    safeRules[normalizedType] = bump;
+  }
+
+  return safeRules;
+}
+
+/**
+ * Normalize a partial user configuration into a complete runtime configuration.
+ *
+ * Missing or invalid values from the provided userConfig are replaced with
+ * defaults from DEFAULT_CONFIG. The function performs the following normalizations:
+ * - tag.prefix: must be a string; otherwise DEFAULT_CONFIG.tag.prefix is used.
+ * - changelog.emojis: must be a boolean; otherwise DEFAULT_CONFIG.changelog.emojis is used.
+ * - releaseRules: DEFAULT_CONFIG.releaseRules are merged with the result of
+ *   validateReleaseRules(userConfig?.releaseRules).
+ *
+ * @param {Object} [userConfig={}] - Partial configuration provided by the user.
+ * @param {Object} [userConfig.tag] - Tag-related settings.
+ * @param {string} [userConfig.tag.prefix] - Tag prefix; if not a string the default is used.
+ * @param {Object} [userConfig.changelog] - Changelog-related settings.
+ * @param {boolean} [userConfig.changelog.emojis] - Whether to include emojis in the changelog; if not boolean the default is used.
+ * @param {*} [userConfig.releaseRules] - Release rules passed to validateReleaseRules; see validateReleaseRules for the expected shape.
+ *
+ * @returns {{ tag: { prefix: string }, changelog: { emojis: boolean }, releaseRules: * }}
+ *   The normalized configuration object with guaranteed shapes for tag and changelog,
+ *   and merged releaseRules.
+ *
+ * @throws {*} Propagates any error thrown by validateReleaseRules when provided releaseRules are invalid.
+ */
 function normalizeConfig(userConfig = {}) {
   return {
     tag: {
       prefix:
-        userConfig?.tag?.prefix === "v"
-          ? "v"
-          : "",
+        typeof userConfig?.tag?.prefix === "string"
+          ? userConfig.tag.prefix
+          : DEFAULT_CONFIG.tag.prefix,
     },
 
     changelog: {
       emojis:
         typeof userConfig?.changelog?.emojis === "boolean"
           ? userConfig.changelog.emojis
-          : false,
+          : DEFAULT_CONFIG.changelog.emojis,
+    },
+
+    releaseRules: {
+      ...DEFAULT_CONFIG.releaseRules,
+      ...validateReleaseRules(userConfig?.releaseRules),
     },
   };
 }
 
+/**
+ * Asynchronously loads and returns a normalized release configuration from a
+ * release.config.js file located in the given working directory.
+ *
+ * Behavior:
+ * - Resolves "release.config.js" inside the provided cwd (defaults to process.cwd()).
+ * - If the file does not exist, returns the result of normalizeConfig() (the default config).
+ * - If the file exists, dynamically imports it via a file:// URL and accepts either
+ *   an ES module default export or a CommonJS export (uses mod.default ?? mod).
+ * - Any error thrown while importing is caught and rethrown as an Error with the
+ *   message prefixed by "Failed to load release.config.js".
+ *
+ * @async
+ * @param {string} [cwd=process.cwd()] - The directory to resolve release.config.js from.
+ * @returns {Promise<object>} Promise that resolves to the normalized configuration (result of normalizeConfig(userConfig)).
+ * @throws {Error} If dynamic import of the configuration file fails.
+ */
 async function loadReleaseConfig(cwd = process.cwd()) {
   const configPath = path.join(cwd, "release.config.js");
 
-  const defaults = {
-    tag: { prefix: "v" },
-    changelog: { emojis: false },
-  };
-
   if (!fs.existsSync(configPath)) {
-    return defaults;
+    return normalizeConfig();
   }
 
   const fileUrl = pathToFileURL(configPath).href;

--- a/lib/versioning.js
+++ b/lib/versioning.js
@@ -1,4 +1,5 @@
 import { normalizeSubject } from "./commits.js";
+import { config } from "./config.js";
 import { COMMIT_RE } from "./constants.js";
 
 /* ===========================
@@ -6,25 +7,30 @@ import { COMMIT_RE } from "./constants.js";
  * =========================== */
 
 /**
- * Determine the semantic version bump implied by a commit message.
+ * Determine the semantic version bump type for a commit message.
  *
- * The function inspects the commit subject and body using a conventional-commit
- * pattern (COMMIT_RE) and the presence of "BREAKING CHANGE":
- * - Returns "major" if the body contains "BREAKING CHANGE" (case-insensitive)
- *   or the commit header contains the conventional "!" breaking-change marker.
- * - Returns "minor" if the header matches COMMIT_RE and the commit type is "feat".
- * - Returns "patch" if the header matches COMMIT_RE and the commit type is "fix".
- * - Returns "none" if no relevant indicators are present.
+ * The function inspects a commit subject and body (e.g. Conventional Commit format)
+ * and returns the appropriate release bump type:
+ * - Normalizes the subject via normalizeSubject(subject) before analysis.
+ * - If the normalized subject begins with "revert" (case-insensitive), returns "none".
+ * - Attempts to parse the subject with COMMIT_RE to extract the commit type and
+ *   optional breaking "!" indicator.
+ * - Considers the body for a "BREAKING CHANGE" token (case-insensitive).
+ * - If a breaking change is detected (body token or "!" marker), returns "major".
+ * - If the subject does not match COMMIT_RE, returns "none".
+ * - Otherwise, looks up the parsed commit type in config.releaseRules and returns
+ *   the configured rule value; if none exists, returns "none".
  *
- * @param {Object} params - Destructured input object.
- * @param {string} params.subject - Commit subject/summary line to be matched against COMMIT_RE.
- * @param {string} params.body - Commit body text used to detect "BREAKING CHANGE".
- * @returns {'major'|'minor'|'patch'|'none'} The semantic version bump type.
+ * Note: This function depends on external symbols: normalizeSubject, COMMIT_RE and config.
+ *
+ * @param {Object} options - Commit data to analyze.
+ * @param {string} options.subject - Commit subject/header.
+ * @param {string} [options.body] - Commit body/description (optional).
+ * @returns {string} The release bump type ("major", a value from config.releaseRules, or "none").
  */
 export function detectBumpType({ subject, body }) {
   const normalizedSubject = normalizeSubject(subject);
 
-  // Ignore revert commits entirely
   if (/^revert\b/i.test(normalizedSubject)) return "none";
 
   const match = normalizedSubject.match(COMMIT_RE);
@@ -36,10 +42,10 @@ export function detectBumpType({ subject, body }) {
   if (!match) return "none";
 
   const type = match[1].toLowerCase();
-  if (type === "feat") return "minor";
-  if (type === "fix") return "patch";
 
-  return "none";
+  const rule = config.releaseRules?.[type];
+
+  return rule ?? "none";
 }
 
 /**

--- a/release.config.js
+++ b/release.config.js
@@ -7,4 +7,11 @@ export default {
   changelog: {
     emojis: true,
   },
+
+  releaseRules: {
+    docs: "patch",
+    ci: "patch",
+    refactor: "patch",
+    perf: "patch",
+  }
 };


### PR DESCRIPTION
# Summary of Adjustments

This PR enhances the configuration system by introducing support for customizable `releaseRules`, allowing consumers to control how commit types map to semantic version bumps.

## ✨ Key changes
- Add `releaseRules` support in `release.config.js`
- Implement default rules (`feat → minor`, `fix → patch`)
- Enable safe merging between user-defined and default rules
- Prevent overrides for critical commit types (`feat`, `fix`)
- Add validation for allowed bump types (`major`, `minor`, `patch`, `none`)
- Improve fallback behavior for partial or missing configurations
- Update documentation to reflect new configuration capabilities

## 🧠 Motivation

Some changes like `docs` and `ci` can affect how users understand or consume the library. This update allows those changes to optionally trigger version bumps, improving release consistency and user trust.

## 🔒 Safety
- Invalid `releaseRules` values throw explicit errors
- Protected commit types cannot be overridden
- Missing configuration fields fall back to stable defaults

## 📚 Docs
- Updated `README.md`
- Expanded `docs/config.md` with `releaseRules` usage and behavior